### PR TITLE
export for browserify's users

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/simpleslider')


### PR DESCRIPTION
just add a `index.js` file, so browserify's users can simply do `require('simple-slider')` instead of things like `require('../../../node_modules/simple-slider/dist/simpleslider')`.

thank you. :smile: 
