### PR TITLE
Link to full docs — README is very shortened

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ I would recommend that you take a look at some of the available alternatives and
 
 - [slick](https://github.com/kenwheeler/slick)
 - [lory](https://github.com/meandmax/lory)
-- [siema](https://github.com/pawelgrzybek/siema)
+- [siema](https://pawelgrzybek.com/siema/)
 - [Swiper](https://github.com/nolimits4web/Swiper)
 - [iSlider](https://github.com/BE-FE/iSlider)
 - [Owl Carousel](https://github.com/OwlCarousel2/OwlCarousel2)


### PR DESCRIPTION
Hi @ruyadorno 

Just came across your lib. Super cool one! Thanks as well for linking to my carousel plugin as an alternative one — really kind of you that you appreciate my script.

It's very quick PR that replaces a link to docs to my library from Github page (which has very brief and shortened) to full docs page.

Thanks again and have a great day.